### PR TITLE
add annotations import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ annotation-file-utilities/javadoc
 annotation-file-utilities/tests/abbreviated/*.diff
 annotation-file-utilities/tests/abbreviated/*.log
 annotation-file-utilities/tests/abbreviated/*.output
+annotation-file-utilities/tests/enum-filed-imports/*.diff
+annotation-file-utilities/tests/enum-filed-imports/*.log
+annotation-file-utilities/tests/enum-filed-imports/*.output
 annotation-file-utilities/tests/ad-hoc/bridge/A.class
 annotation-file-utilities/tests/ad-hoc/bridge/C.class
 annotation-file-utilities/tests/ad-hoc/bridge/C.jaif

--- a/annotation-file-utilities/src/annotator/Main.java
+++ b/annotation-file-utilities/src/annotator/Main.java
@@ -682,10 +682,8 @@ public class Main {
       // Imports required to resolve annotations (when abbreviate==true).
       LinkedHashSet<String> imports = new LinkedHashSet<String>();
       // add annotation imports first
-      if (!annotationImports.isEmpty()) {
-          for (Set<String> importSet : annotationImports.values()) {
-              imports.addAll(importSet);
-          }
+      for (Set<String> importSet : annotationImports.values()) {
+          imports.addAll(importSet);
       }
 
       int num_insertions = 0;

--- a/annotation-file-utilities/src/annotator/Main.java
+++ b/annotation-file-utilities/src/annotator/Main.java
@@ -553,6 +553,8 @@ public class Main {
         new HashMap<String, Multimap<Insertion, Annotation>>();
     Map<Insertion, String> insertionOrigins = new HashMap<Insertion, String>();
     Map<String, AScene> scenes = new HashMap<String, AScene>();
+    // maintain imports info for annotations field
+    Map<String, Set<String>> annotationImports = new HashMap<>();
 
     IndexFileParser.setAbbreviate(abbreviate);
     for (String arg : file_args) {
@@ -625,6 +627,7 @@ public class Main {
           }
           System.exit(1);
         }
+        annotationImports.putAll(spec.annotationImports());
       } else {
         throw new Error("Unrecognized file extension: " + arg);
       }
@@ -678,6 +681,13 @@ public class Main {
 
       // Imports required to resolve annotations (when abbreviate==true).
       LinkedHashSet<String> imports = new LinkedHashSet<String>();
+      // add annotation imports first
+      if (!annotationImports.isEmpty()) {
+          for (Set<String> importSet : annotationImports.values()) {
+              imports.addAll(importSet);
+          }
+      }
+
       int num_insertions = 0;
       String pkg = "";
 

--- a/annotation-file-utilities/src/annotator/Main.java
+++ b/annotation-file-utilities/src/annotator/Main.java
@@ -688,7 +688,6 @@ public class Main {
 
       // Imports required to resolve annotations (when abbreviate==true).
       LinkedHashSet<String> imports = new LinkedHashSet<String>();
-
       int num_insertions = 0;
       String pkg = "";
 

--- a/annotation-file-utilities/src/annotator/Main.java
+++ b/annotation-file-utilities/src/annotator/Main.java
@@ -879,7 +879,9 @@ public class Main {
             if (iToInsert instanceof AnnotationInsertion) {
                 AnnotationInsertion annoToInsert = (AnnotationInsertion) iToInsert;
                 Set<String> annoImports = annotationImports.get(annoToInsert.getAnnotationBaseName());
-                imports.addAll(annoImports);
+                if (annoImports != null) {
+                    imports.addAll(annoImports);
+                }
             }
           }
         }

--- a/annotation-file-utilities/src/annotator/find/AnnotationInsertion.java
+++ b/annotation-file-utilities/src/annotator/find/AnnotationInsertion.java
@@ -78,7 +78,6 @@ public class AnnotationInsertion extends Insertion {
         String result = annotation;
         if (abbreviate) {
             Pair<String, String> ps = removePackage(result);
-
             String packageName = ps.a;
             if (packageName != null) {
                 packageNames.add(packageName);

--- a/annotation-file-utilities/src/annotator/find/AnnotationInsertion.java
+++ b/annotation-file-utilities/src/annotator/find/AnnotationInsertion.java
@@ -11,6 +11,8 @@ public class AnnotationInsertion extends Insertion {
      * The annotation to insert.
      */
     private final String annotation;
+    // the base name of the annotation to be inserted
+    private final String annotationBaseName;
     private String type;
     private boolean generateBound;
     private boolean generateExtends;
@@ -27,6 +29,7 @@ public class AnnotationInsertion extends Insertion {
     public AnnotationInsertion(String annotation, Criteria criteria, boolean separateLine) {
         super(criteria, separateLine);
         this.annotation = annotation;
+        this.annotationBaseName = extractAnnotationBaseName(annotation);
         type = null;
         generateBound = false;
         generateExtends = false;
@@ -75,6 +78,7 @@ public class AnnotationInsertion extends Insertion {
         String result = annotation;
         if (abbreviate) {
             Pair<String, String> ps = removePackage(result);
+
             String packageName = ps.a;
             if (packageName != null) {
                 packageNames.add(packageName);
@@ -102,11 +106,45 @@ public class AnnotationInsertion extends Insertion {
     }
 
     /**
+     * Extract the base name of the <code>annotation</code>.
+     * @param annotation the string representation of the <code>annotation</code> passed to the constructor
+     * @return given <code>@com.foo.bar(baz)</code> it returns the base name of this annotation
+     *         <code>bar</code>.
+     */
+    private String extractAnnotationBaseName(String annotation) {
+        assert annotation.startsWith("@");
+        // annotation always starts with "@", so annotation name begin at least at index 1 in the string.
+        int nameBegin = 1;
+        int nameEnd = annotation.indexOf("(");
+        int dotIndex = annotation.lastIndexOf(".", nameEnd);
+
+        // for the case @TA, name end at the last index
+        if (nameEnd == -1) {
+            nameEnd = annotation.length();
+        }
+
+        // base name begin at the next index of the last "." in
+        // the annotation string representation (if there were any "." exists)
+        if (dotIndex != -1) {
+            nameBegin = dotIndex + 1;
+        }
+        return annotation.substring(nameBegin, nameEnd);
+    }
+
+    /**
      * Gets the raw, unmodified annotation that was passed into the constructor.
      * @return the annotation.
      */
     public String getAnnotation() {
         return annotation;
+    }
+
+    /**
+     * Get the base name of the annotation.
+     * @return the annotation base name
+     */
+    public String getAnnotationBaseName() {
+        return annotationBaseName;
     }
 
     /** {@inheritDoc} */

--- a/annotation-file-utilities/tests/enum-filed-imports/C.goal
+++ b/annotation-file-utilities/tests/enum-filed-imports/C.goal
@@ -1,0 +1,6 @@
+import foo.qual.TA;
+import foo.bar.EnumClass;
+public class C {
+    @TA(EnumClass.EnumValue)
+    Object f;
+}

--- a/annotation-file-utilities/tests/enum-filed-imports/C.jaif
+++ b/annotation-file-utilities/tests/enum-filed-imports/C.jaif
@@ -1,0 +1,8 @@
+package foo.qual:
+  annotation @TA:
+    enum foo.bar.EnumClass value
+
+package :
+class C:
+  field f:
+  @TA(value=EnumValue)

--- a/annotation-file-utilities/tests/enum-filed-imports/C.java
+++ b/annotation-file-utilities/tests/enum-filed-imports/C.java
@@ -1,0 +1,3 @@
+public class C {
+    Object f;
+}

--- a/annotation-file-utilities/tests/enum-filed-imports/Makefile
+++ b/annotation-file-utilities/tests/enum-filed-imports/Makefile
@@ -7,23 +7,27 @@
 
 # Put user-specific changes in your own Makefile.user.
 # Make will silently continue if that file does not exist.
--include Makefile.user
+-include ../Makefile.user
 
 # Override these in Makefile.user if the java and javac commands are not on
 # your execution path.  Example from Makefile.user:
 #   JAVA=${JAVA_HOME}/bin/java
 #   JAVAC=${JAVA_HOME}/bin/javac
-export JAVA?=java -ea
-export JAVAC?=javac
-export XJAVAC?=javac
+JAVA?=java
+JAVAC?=javac
 
 export SHELL=/bin/bash -o pipefail
 
 
+#filter-out reverses order, so use tac to reverse its input first
 DIFFS := $(wildcard *.goal)
 DISABLED := $(shell grep -le "@skip-test" $(DIFFS))
 FILTERED := $(filter-out $(DISABLED),$(DIFFS))
 DIFFS := $(patsubst %.goal, %.diff, $(FILTERED))
+AFU_JARS := ../../lib/plume.jar ../../annotation-file-utilities.jar
+JAIF := C.jaif
+SRC := $(patsubst %.goal, %.java, $(FILTERED))
+OUT := $(patsubst %.goal, %.output, $(FILTERED))
 
 DEBUG :=
 # Use this to enable some debugging.
@@ -32,71 +36,47 @@ DEBUG :=
 default : all
 
 .PHONY: all
-all : $(DIFFS) abbreviated enum-filed-imports ad-hoc system-test source-extension results
-
-.PHONY: abbreviated
-abbreviated:
-	${MAKE} -C abbreviated
-
-.PHONY: enum-filed-imports
-enum-filed-imports:
-	${MAKE} -C enum-filed-imports
-
-.PHONY: ad-hoc
-ad-hoc:
-	${MAKE} -C ad-hoc
-
-.PHONY: source-extension
-source-extension:
-	${MAKE} -C source-extension
-
-.PHONY: system-test
-system-test:
-	${MAKE} -C system-test
+all : $(DIFFS) results
 
 # Display results of all .diff files.
 .PHONY: results
-results: bin/VerifyDiffs.class
+results: ../bin/VerifyDiffs.class
+	@rm -rf output
 	@echo ""
 	@echo "=== RESULTS ==="
 	@echo ""
-	@$(JAVA) -cp bin VerifyDiffs --show_all
+	@$(JAVA) -cp bin:../bin VerifyDiffs --show_all
 
 # Remakes the little java program that checks and compares diffs
-bin/VerifyDiffs.class : VerifyDiffs.java
-	@$(JAVAC) -g -cp ../bincompile -d bin VerifyDiffs.java
+../bin/VerifyDiffs.class : ../VerifyDiffs.java
+	@$(JAVAC) -g -cp ../../bincompile -d ../bin ../VerifyDiffs.java
 
 # Compiles all the test cases (be verbose about this).
-compile :
+.PHONY: compile
+compile : $(SRC)
 	mkdir -p bin
-	$(XJAVAC) -g -cp ../bin -d bin *.java
-
-.PRECIOUS : bin/annotator/tests/%.class
-bin/annotator/tests/%.class: %.java
-	mkdir -p bin
-# Added "-Xlint:-options" to see if it permits Jenkins job to succeed, due to
-# problem "target value 1.8 is obsolete and will be removed in a future release"
-	$(XJAVAC) -Xlint:-options -g -cp bin:../annotation-file-utilities.jar -d bin -sourcepath . $*.java
+	$(JAVAC) -g -cp bin:../../bin -d bin -sourcepath . $(SRC)
 
 # Actually runs the annotator to create the annotated java file.
 # We are required to put annotation-file-utilities.jar (and ../bin) on the
 # bootclasspath so that the JSR 308 javac classes bundled therein are found
 # before the stock javac classes that the Mac OS includes on the bootclasspath
 # (other platforms do not make such inclusions)
-.PRECIOUS: %.output
-%.output: %.jaif %.java bin/annotator/tests/%.class ../lib/plume.jar ../bin ../annotation-file-utilities.jar
+output: compile $(JAIF) ../../bin $(AFU_JARS)
 	$(JAVA) \
-        -Xbootclasspath/p:../bin:../annotation-file-utilities.jar \
-        -cp bin \
+        -Xbootclasspath/p:../../bin:../../annotation-file-utilities.jar \
+	-cp bin \
 	annotator.Main \
 	${DEBUG} \
-	--abbreviate=false \
-	-d $*-output \
-	$*.jaif \
-	$*.java \
-	2>&1 | tee $*.log
-	find "$*-output" -name '*.java' -print | xargs cat > "$*.output"
-	rm -rf $*-output
+	--abbreviate=true \
+	-d output \
+	$(JAIF) \
+	$(SRC) \
+	2>&1 | tee C.log
+
+.PRECIOUS: %.output
+%.output: output
+	find output -name "$*.java" -print | xargs cat > "$*.output"
 
 # Compare the output of the annotator and the goal file.
 %.diff: %.goal %.output
@@ -109,6 +89,3 @@ clean :
 	rm -f *.diff
 	rm -f *.log
 	rm -f *.output
-	(cd abbreviated && make clean)
-	(cd enum-filed-imports && make clean)
-	(cd ad-hoc && make clean)

--- a/scene-lib/src/annotations/el/AScene.java
+++ b/scene-lib/src/annotations/el/AScene.java
@@ -63,6 +63,8 @@ public final class AScene implements Cloneable {
      * Contains for each annotation type a set of imports to be added to
      *  the source if the annotation is inserted with the "abbreviate"
      *  option on.
+     *  Key: base name of an annotation. e.g. for <code>@com.foo.bar(x)</code>, the base name is <code>bar</code>
+     *  Value: names of packages this annotation needs
      */
     public final Map<String, Set<String>> imports =
         new LinkedHashMap<String, Set<String>>();

--- a/scene-lib/src/annotations/io/IndexFileParser.java
+++ b/scene-lib/src/annotations/io/IndexFileParser.java
@@ -569,7 +569,7 @@ public final class IndexFileParser {
                 }
                 if (set2 == null) {
                   set2 = new TreeSet<String>();
-                  scene.imports.put(name, set2);
+                  scene.imports.put(baseName, set2);
                 }
                 set1.add(name);
                 set2.add(name);

--- a/scene-lib/src/annotations/io/IndexFileParser.java
+++ b/scene-lib/src/annotations/io/IndexFileParser.java
@@ -546,7 +546,7 @@ public final class IndexFileParser {
         }
     }
 
-    private ScalarAFT parseScalarAFT() throws IOException, ParseException {
+    private ScalarAFT parseScalarAFT(String annotationBaseName) throws IOException, ParseException {
         for (BasicAFT baft : BasicAFT.bafts.values()) {
             if (matchKeyword(baft.toString())) {
                 return baft;
@@ -561,10 +561,10 @@ public final class IndexFileParser {
               int i = name.lastIndexOf('.');
               if (i >= 0) {
                 String baseName = name.substring(i+1);
-                Set<String> importSet = scene.imports.get(baseName);
+                Set<String> importSet = scene.imports.get(annotationBaseName);
                 if (importSet == null) {
                   importSet = new TreeSet<String>();
-                  scene.imports.put(baseName, importSet);
+                  scene.imports.put(annotationBaseName, importSet);
                 }
                 importSet.add(name);
                 name = baseName;
@@ -586,7 +586,7 @@ public final class IndexFileParser {
         }
     }
 
-    private AnnotationFieldType parseAFT() throws IOException,
+    private AnnotationFieldType parseAFT(String annotationBaseName) throws IOException,
             ParseException {
         if (matchKeyword("unknown")) {
             // Handle unknown[]; see AnnotationBuilder#addEmptyArrayField
@@ -594,7 +594,7 @@ public final class IndexFileParser {
             expectChar(']');
             return new ArrayAFT(null);
         }
-        ScalarAFT baseAFT = parseScalarAFT();
+        ScalarAFT baseAFT = parseScalarAFT(annotationBaseName);
         // only one level of array is permitted
         if (matchChar('[')) {
             expectChar(']');
@@ -620,7 +620,7 @@ public final class IndexFileParser {
         // yuck; it would be nicer to do a positive match
         while (st.ttype != TT_EOF && !checkKeyword("annotation")
                && !checkKeyword("class") && !checkKeyword("package")) {
-            AnnotationFieldType type = parseAFT();
+            AnnotationFieldType type = parseAFT(basename);
             String name = expectIdentifier();
             if (fields.containsKey(name)) {
                 throw new ParseException("Duplicate definition of field "

--- a/scene-lib/src/annotations/io/IndexFileParser.java
+++ b/scene-lib/src/annotations/io/IndexFileParser.java
@@ -561,18 +561,12 @@ public final class IndexFileParser {
               int i = name.lastIndexOf('.');
               if (i >= 0) {
                 String baseName = name.substring(i+1);
-                Set<String> set1 = scene.imports.get(name);
-                Set<String> set2 = scene.imports.get(baseName);
-                if (set1 == null) {
-                  set1 = new TreeSet<String>();
-                  scene.imports.put(name, set1);
+                Set<String> importSet = scene.imports.get(baseName);
+                if (importSet == null) {
+                  importSet = new TreeSet<String>();
+                  scene.imports.put(baseName, importSet);
                 }
-                if (set2 == null) {
-                  set2 = new TreeSet<String>();
-                  scene.imports.put(baseName, set2);
-                }
-                set1.add(name);
-                set2.add(name);
+                importSet.add(name);
                 name = baseName;
               }
             }


### PR DESCRIPTION
Propagate `annotationImports` information stored in `Ascene spec` to `imports` in `Main`.

This could enable  AFU also import the class of enum field of an annotation if that enum field declared with full qualified name in jaif file like this:

```
package ontology.qual:
  annotation @Ontology:
    enum ontology.qual.OntologyValue[] values
```

The imports of above jaif file in source code would be:

```java
import ontology.qual.Ontology;
import ontology.qual.OntologyValue; // note, this one is extracted by the 
                                    // full qualified declaration of 
                                    // `enum ontology.qual.OntologyValue[] values` in jaif file,
                                   // not inferred by package declaration.
```