### PR TITLE
Directly return field value without appending typeName when field value is qualified.

### DIFF
--- a/annotation-file-utilities/tests/AnnotationEnumFieldInsertion.goal
+++ b/annotation-file-utilities/tests/AnnotationEnumFieldInsertion.goal
@@ -1,0 +1,6 @@
+public class AnnotationEnumFieldInsertion {
+    void test() {
+        @fakeChecker.qual.Annotation(values={fakeChecker.qual.EnumClass.ENUM_CONSTANT})
+        int i = 1;
+    }
+}

--- a/annotation-file-utilities/tests/AnnotationEnumFieldInsertion.jaif
+++ b/annotation-file-utilities/tests/AnnotationEnumFieldInsertion.jaif
@@ -1,0 +1,8 @@
+package fakeChecker.qual:
+  annotation @Annotation:
+    enum EnumClass[] values
+
+package :
+class AnnotationEnumFieldInsertion:
+method test()V:
+insert-annotation Method.body, Block.statement 0, Variable.type: @fakeChecker.qual.Annotation(values={fakeChecker.qual.EnumClass.ENUM_CONSTANT})

--- a/annotation-file-utilities/tests/AnnotationEnumFieldInsertion.java
+++ b/annotation-file-utilities/tests/AnnotationEnumFieldInsertion.java
@@ -1,0 +1,5 @@
+public class AnnotationEnumFieldInsertion {
+    void test() {
+        int i = 1;
+    }
+}

--- a/scene-lib/src/annotations/field/EnumAFT.java
+++ b/scene-lib/src/annotations/field/EnumAFT.java
@@ -49,7 +49,7 @@ public final class EnumAFT extends ScalarAFT {
         String fieldValue = o.toString();
         if (!fieldValue.contains(".")) {
             // If fieldValue is not qualified, prepend the typeName
-            return typeName + fieldValue;
+            return typeName + "." + fieldValue;
         }
         return fieldValue;
     }

--- a/scene-lib/src/annotations/field/EnumAFT.java
+++ b/scene-lib/src/annotations/field/EnumAFT.java
@@ -46,7 +46,13 @@ public final class EnumAFT extends ScalarAFT {
      */
     @Override
     public String format(Object o) {
-        return typeName + "." + o.toString();
+        String fieldValue = o.toString();
+        if (fieldValue.contains(".")) {
+            //if fieldValue is a qualified value, then return it without appending the typeName
+            return fieldValue;
+        } else {
+            return typeName + "." + fieldValue;
+        }
     }
 
 

--- a/scene-lib/src/annotations/field/EnumAFT.java
+++ b/scene-lib/src/annotations/field/EnumAFT.java
@@ -47,12 +47,11 @@ public final class EnumAFT extends ScalarAFT {
     @Override
     public String format(Object o) {
         String fieldValue = o.toString();
-        if (fieldValue.contains(".")) {
-            //if fieldValue is a qualified value, then return it without appending the typeName
-            return fieldValue;
-        } else {
-            return typeName + "." + fieldValue;
+        if (!fieldValue.contains(".")) {
+            // If fieldValue is not qualified, prepend the typeName
+            return typeName + fieldValue;
         }
+        return fieldValue;
     }
 
 


### PR DESCRIPTION
Fix issue: https://github.com/typetools/annotation-tools/issues/124

This issue cause me failed to add testing framework for Ontology, as the insertion result cannot compile.